### PR TITLE
resolve dependency for statusmodels and change installing way

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In Proceedings of [the 2018 Conference on Empirical Methods in Natural Language 
 ## Installation
 
 ```
-$ pip install phsic-cli
+$ pip install ./
 ```
 
 This will install `phsic` command to your environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ sklearn = "^0.0.0"
 tensorflow = "^1.7"
 tensorflow-hub = "^0.1.1"
 scipy = "^1.1"
-statsmodels = "^0.9.0"
+statsmodels = "^0.10.0"
 pandas = "^0.23.4"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
statsmodelsがscipyの指定versionで読み込みの不整合を起こしたので、statsmodelsのversionをあげました。
それに伴い、localのversion指定でinstallさせる必要があるため、install手順を変更しました。